### PR TITLE
Use collective communications

### DIFF
--- a/bra/Makefile
+++ b/bra/Makefile
@@ -28,6 +28,7 @@ macros += KET_USE_OPENMP
 macros += KET_USE_DIAGONAL_LOOP
 macros += KET_USE_BARRIER
 #macros += BRAKET_ENABLE_MULTIPLE_USES_OF_BUFFER_FOR_ONE_DATA_TRANSFER_IF_NO_PAGE_EXISTS
+macros += KET_USE_COLLECTIVE_COMMUNICATIONS
 libraries =
 
 CPPFLAGS = $(addprefix -I,$(idirs)) $(addprefix -D,$(macros))

--- a/bra/include/bra/simple_mpi_state.hpp
+++ b/bra/include/bra/simple_mpi_state.hpp
@@ -7,7 +7,6 @@
 #   include <ket/gate/projective_measurement.hpp>
 #   include <ket/utility/parallel/loop_n.hpp>
 #   include <ket/mpi/utility/simple_mpi.hpp>
-#   include <ket/mpi/state.hpp>
 
 #   include <yampi/allocator.hpp>
 #   include <yampi/rank.hpp>
@@ -25,7 +24,7 @@ namespace bra
     ket::utility::policy::parallel<unsigned int> parallel_policy_;
     ket::mpi::utility::policy::simple_mpi mpi_policy_;
 
-    using data_type = ket::mpi::state<complex_type, false, yampi::allocator<complex_type>>;
+    using data_type = std::vector<complex_type, yampi::allocator<complex_type>>;
     data_type data_;
 
    public:
@@ -60,6 +59,11 @@ namespace bra
     simple_mpi_state& operator=(simple_mpi_state&&) = delete;
 
    private:
+    data_type generate_initial_data(
+      unsigned int const num_local_qubits,
+      ::bra::state::state_integer_type const initial_integer,
+      yampi::communicator const& communicator, yampi::environment const& environment) const;
+
     unsigned int do_num_page_qubits() const override;
     unsigned int do_num_pages() const override;
 

--- a/bra/include/bra/unit_mpi_state.hpp
+++ b/bra/include/bra/unit_mpi_state.hpp
@@ -27,7 +27,7 @@ namespace bra
       = ket::mpi::utility::policy::unit_mpi< ::bra::state::state_integer_type, ::bra::state::bit_integer_type, unsigned int >;
     unit_mpi_policy_type mpi_policy_;
 
-    using data_type = ket::mpi::state<complex_type, false, yampi::allocator<complex_type>>;
+    using data_type = std::vector<complex_type, yampi::allocator<complex_type>>;
     data_type data_;
 
    public:
@@ -66,6 +66,10 @@ namespace bra
     unit_mpi_state& operator=(unit_mpi_state&&) = delete;
 
    private:
+    data_type generate_initial_data(
+      unsigned int const num_local_qubits,
+      ::bra::state::state_integer_type const initial_integer,
+      yampi::communicator const& communicator, yampi::environment const& environment) const;
 
     unsigned int do_num_page_qubits() const override;
     unsigned int do_num_pages() const override;

--- a/bra/src/simple_mpi_state.cpp
+++ b/bra/src/simple_mpi_state.cpp
@@ -47,9 +47,7 @@ namespace bra
     : ::bra::state{total_num_qubits, seed, communicator, environment},
       parallel_policy_{num_threads_per_process},
       mpi_policy_{},
-      data_{
-        mpi_policy_, num_local_qubits, initial_integer,
-        permutation_, communicator, environment}
+      data_{generate_initial_data(num_local_qubits, initial_integer, communicator, environment)}
   { }
 
   simple_mpi_state::simple_mpi_state(
@@ -63,9 +61,7 @@ namespace bra
     : ::bra::state{initial_permutation, seed, communicator, environment},
       parallel_policy_{num_threads_per_process},
       mpi_policy_{},
-      data_{
-        mpi_policy_, num_local_qubits, initial_integer,
-        permutation_, communicator, environment}
+      data_{generate_initial_data(num_local_qubits, initial_integer, communicator, environment)}
   { }
 # else // BRAKET_ENABLE_MULTIPLE_USES_OF_BUFFER_FOR_ONE_DATA_TRANSFER_IF_NO_PAGE_EXISTS
   simple_mpi_state::simple_mpi_state(
@@ -80,9 +76,7 @@ namespace bra
     : ::bra::state{total_num_qubits, seed, num_elements_in_buffer, communicator, environment},
       parallel_policy_{num_threads_per_process},
       mpi_policy_{},
-      data_{
-        mpi_policy_, num_local_qubits, initial_integer,
-        permutation_, communicator, environment}
+      data_{generate_initial_data(num_local_qubits, initial_integer, communicator, environment)}
   { }
 
   simple_mpi_state::simple_mpi_state(
@@ -97,11 +91,30 @@ namespace bra
     : ::bra::state{initial_permutation, seed, num_elements_in_buffer, communicator, environment},
       parallel_policy_{num_threads_per_process},
       mpi_policy_{},
-      data_{
-        mpi_policy_, num_local_qubits, initial_integer,
-        permutation_, communicator, environment}
+      data_{generate_initial_data(num_local_qubits, initial_integer, communicator, environment)}
   { }
 # endif // BRAKET_ENABLE_MULTIPLE_USES_OF_BUFFER_FOR_ONE_DATA_TRANSFER_IF_NO_PAGE_EXISTS
+
+  simple_mpi_state::data_type simple_mpi_state::generate_initial_data(
+    unsigned int const num_local_qubits,
+    ::bra::state::state_integer_type const initial_integer,
+    yampi::communicator const& communicator, yampi::environment const& environment) const
+  {
+    auto result
+      = data_type(
+          ket::utility::integer_exp2<std::size_t>(num_local_qubits)
+            * ket::mpi::utility::policy::num_data_blocks(mpi_policy_, communicator, environment),
+          complex_type{0});
+
+    auto const rank_index
+      = ket::mpi::utility::qubit_value_to_rank_index(
+          mpi_policy_, data_, ket::mpi::permutate_bits(permutation_, initial_integer),
+          communicator, environment);
+    if (communicator.rank(environment) == rank_index.first)
+      result[rank_index.second] = complex_type{1};
+
+    return result;
+  }
 
   void simple_mpi_state::do_hadamard(qubit_type const qubit)
   {

--- a/bra/src/state.cpp
+++ b/bra/src/state.cpp
@@ -41,7 +41,7 @@ namespace bra
       random_number_generator_{seed},
       permutation_{static_cast<permutation_type::size_type>(total_num_qubits)},
       buffer_{},
-      real_pair_datatype_{yampi::predefined_datatype<real_type>(), 2, environment},
+      real_pair_datatype_{yampi::predefined_datatype<real_type>(), yampi::count{2}, environment},
       communicator_{communicator},
       environment_{environment},
       finish_times_and_processes_{}
@@ -61,7 +61,7 @@ namespace bra
       random_number_generator_{seed},
       permutation_{static_cast<permutation_type::size_type>(total_num_qubits)},
       buffer_(num_elements_in_buffer),
-      real_pair_datatype_{yampi::predefined_datatype<real_type>(), 2, environment},
+      real_pair_datatype_{yampi::predefined_datatype<real_type>(), yampi::count{2}, environment},
       communicator_{communicator},
       environment_{environment},
       finish_times_and_processes_{}
@@ -81,7 +81,7 @@ namespace bra
       permutation_{
         std::begin(initial_permutation), std::end(initial_permutation)},
       buffer_{},
-      real_pair_datatype_{yampi::predefined_datatype<real_type>(), 2, environment},
+      real_pair_datatype_{yampi::predefined_datatype<real_type>(), yampi::count{2}, environment},
       communicator_{communicator},
       environment_{environment},
       finish_times_and_processes_{}
@@ -102,7 +102,7 @@ namespace bra
       permutation_{
         std::begin(initial_permutation), std::end(initial_permutation)},
       buffer_(num_elements_in_buffer),
-      real_pair_datatype_{yampi::predefined_datatype<real_type>(), 2, environment},
+      real_pair_datatype_{yampi::predefined_datatype<real_type>(), yampi::count{2}, environment},
       communicator_{communicator},
       environment_{environment},
       finish_times_and_processes_{}

--- a/ket/include/ket/mpi/utility/simple_mpi.hpp
+++ b/ket/include/ket/mpi/utility/simple_mpi.hpp
@@ -581,7 +581,7 @@ namespace ket
             for (auto index = std::size_t{0u}; index <= num_qubits_of_operation; ++index)
               color_integer |= ((global_qubit_value >> index) bitand global_qubit_value_masks[index]);
 
-            return std::make_pair(yampi::color{static_cast<int>(color_integer)}, key);
+            return {yampi::color{static_cast<int>(color_integer)}, static_cast<int>(key)};
           }
 
           template <typename LocalState, typename StateInteger, typename BitInteger, typename Function>

--- a/ket/include/ket/mpi/utility/unit_mpi.hpp
+++ b/ket/include/ket/mpi/utility/unit_mpi.hpp
@@ -789,7 +789,7 @@ namespace ket
               {
                 // xx0xx0xx0xxx
                 auto nonlocal_qubit_value_base = StateInteger{0u};
-                for (auto index = std::size_t{0u}; index < num_qubits_of_operation + std::size_t{1u}; ++index)
+                for (auto index = std::size_t{0u}; index <= num_qubits_of_operation; ++index)
                   nonlocal_qubit_value_base
                     |= (nonlocal_qubit_value_wo_qubits bitand nonlocal_qubit_value_masks[index]) << index;
 

--- a/ket/include/ket/mpi/utility/unit_mpi.hpp
+++ b/ket/include/ket/mpi/utility/unit_mpi.hpp
@@ -990,8 +990,12 @@ namespace ket
 
               datatypes[target_local_rank.mpi_rank()]
                 = yampi::datatype{
-                    datatype, transferring_chunk_displacements_first + first_index,
-                    transferring_chunk_displacements_first + last_index, static_cast<int>(chunk_size), environment};
+                    datatype,
+                    yampi::fixed_blocks{
+                      yampi::count{chunk_size},
+                      transferring_chunk_displacements_first + first_index,
+                      transferring_chunk_displacements_first + last_index},
+                    environment};
             }
 
             {


### PR DESCRIPTION
Fix #129 
Define `KET_USE_COLLECTIVE_COMMUNICATIONS` macro if one would like to use this feature.